### PR TITLE
Pam 2264 min side ny arbeidssoker

### DIFF
--- a/pam-frontend-header/package-lock.json
+++ b/pam-frontend-header/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pam-frontend-header",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/pam-frontend-header/package.json
+++ b/pam-frontend-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pam-frontend-header",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Header for PAMs frontend-applikasjoner",
   "author": "akselw",
   "license": "MIT",

--- a/pam-frontend-header/src/index.tsx
+++ b/pam-frontend-header/src/index.tsx
@@ -4,6 +4,7 @@ import { VelgArbeidsgiver } from './arbeidsgiver/VelgArbeidsgiver';
 import { VeilederHeaderMeny, VeilederTabId } from './veileder/HeaderMeny';
 import { PersonbrukerHeaderMeny } from "./personbruker/PersonbrukerHeaderMeny";
 import { PersonbrukerHeader } from './personbruker/PersonbrukerHeader';
+import { PersonbrukerApplikasjon } from './personbruker/InnloggetMeny';
 
 export {
     ArbeidsgiverHeader,
@@ -13,6 +14,7 @@ export {
     VeilederHeaderMeny,
     VeilederTabId,
     PersonbrukerHeaderMeny,
-    PersonbrukerHeader
+    PersonbrukerHeader,
+    PersonbrukerApplikasjon
 }
 

--- a/pam-frontend-header/src/personbruker/InnloggetMeny.tsx
+++ b/pam-frontend-header/src/personbruker/InnloggetMeny.tsx
@@ -194,7 +194,7 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
                         <div className="mobilmeny--separator" />
                         {tabs.map((tab) => (
                             applikasjon === tab.app ? (
-                                tab.href === '/pam-stillingsok' ? (
+                                tab.href === '/' ? (
                                     <div className="mobilmeny--lenke-wrapper" key={tab.href}>
                                         <NavLink onClick={this.hideMenu} isActive={stillingssokTabActive} to={tab.href} activeClassName="mobilmeny--lenke-active" className="mobilmeny--lenke">
                                             <Normaltekst className="mobilmeny--lenke-inner">{tab.tittel}<NavFrontendChevron className="mobilmeny--chevron" /></Normaltekst>

--- a/pam-frontend-header/src/personbruker/InnloggetMeny.tsx
+++ b/pam-frontend-header/src/personbruker/InnloggetMeny.tsx
@@ -16,7 +16,7 @@ export interface PersonbrukerTab {
     app: PersonbrukerApplikasjon
 }
 
-const tabs : Array<PersonbrukerTab> = [
+const allTabs : Array<PersonbrukerTab> = [
     {
         tittel: 'Min side',
         href: '/cv',
@@ -24,17 +24,17 @@ const tabs : Array<PersonbrukerTab> = [
     },
     {
         tittel: 'Stillingssøk',
-        href: '/stillinger',
+        href: '/',
         app: PersonbrukerApplikasjon.STILLINGSSOK
     },
     {
         tittel: 'Favoritter',
-        href: '/stillinger/favoritter',
+        href: '/pam-stillingsok/favoritter',
         app: PersonbrukerApplikasjon.STILLINGSSOK
     },
     {
         tittel: 'Lagrede søk',
-        href: '/stillinger/lagrede-sok',
+        href: '/pam-stillingsok/lagrede-sok',
         app: PersonbrukerApplikasjon.STILLINGSSOK
     },
     {
@@ -50,10 +50,29 @@ const tabs : Array<PersonbrukerTab> = [
 
 ];
 
+const stillingssokTabs : Array<PersonbrukerTab> = [
+    {
+        tittel: 'Stillingssøk',
+        href: '/',
+        app: PersonbrukerApplikasjon.STILLINGSSOK
+    },
+    {
+        tittel: 'Favoritter',
+        href: '/pam-stillingsok/favoritter',
+        app: PersonbrukerApplikasjon.STILLINGSSOK
+    },
+    {
+        tittel: 'Lagrede søk',
+        href: '/pam-stillingsok/lagrede-sok',
+        app: PersonbrukerApplikasjon.STILLINGSSOK
+    }
+];
+
 interface InnloggetToppProps {
     onLoggUt: () => void;
-    personbruker: { navn: string }
-    applikasjon: PersonbrukerApplikasjon
+    personbruker: { navn: string };
+    applikasjon: PersonbrukerApplikasjon;
+    visAlleMenyPunkter: boolean;
 }
 
 interface StateProps {
@@ -64,7 +83,7 @@ const stillingssokTabActive = (match : any, location : any) => {
     if (!match) {
         return false;
     }
-    return location.pathname === "/stillinger" || location.pathname.match(/\/stillinger\/stilling*/);
+    return location.pathname === "/" || location.pathname.match(/\/pam-stillingsok\/stilling*/);
 };
 
 export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProps> {
@@ -89,8 +108,9 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
 
 
     render() {
-        const { personbruker, onLoggUt, applikasjon } = this.props;
+        const { personbruker, onLoggUt, applikasjon, visAlleMenyPunkter } = this.props;
         const { showMobileMenu } = this.state;
+        const tabs = visAlleMenyPunkter ? allTabs : stillingssokTabs;
         return (
             <div className="Innloggetmeny">
                 <div className="topp">
@@ -102,14 +122,14 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
                             {personbruker && personbruker.navn && (
                                 <div>
                                     {applikasjon === PersonbrukerApplikasjon.STILLINGSSOK ? (
-                                        <NavLink to="/stillinger/innstillinger" className="meny--navn lenke typo-normal" activeClassName="meny--navn-active">
+                                        <NavLink to="/pam-stillingsok/innstillinger" className="meny--navn lenke typo-normal" activeClassName="meny--navn-active">
                                             <div className="meny--navn-inner" tabIndex={-1}>
                                                 <span className="meny--navn__text">{personbruker.navn}</span>
                                                 <span className="meny--tannhjul"/>
                                             </div>
                                         </NavLink>
                                     ) : (
-                                        <a href="/stillinger/innstillinger" className="meny--navn lenke typo-normal">
+                                        <a href="/pam-stillingsok/innstillinger" className="meny--navn lenke typo-normal">
                                             <div className="meny--navn-inner" tabIndex={-1}>
                                                 <span className="meny--navn__text">{personbruker.navn}</span>
                                                 <span className="meny--tannhjul"/>
@@ -142,7 +162,7 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
                 <div className="meny">
                     {tabs.map((tab) => (
                         applikasjon === tab.app ? (
-                            tab.href === '/stillinger' ? (
+                            tab.href === '/pam-stillingsok' ? (
                                 <div className="meny--lenke-wrapper" key={tab.href}>
                                     <NavLink to={tab.href} isActive={stillingssokTabActive} activeClassName="meny--lenke-active" className="meny--lenke lenke">
                                         <span className="meny--lenke-inner" tabIndex={-1}>{tab.tittel}<NavFrontendChevron className="meny--chevron" /></span>
@@ -164,7 +184,7 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
                         )
                     ))}
                     <div className="meny--lenke-wrapper">
-                        <NavLink to="/stillinger/innstillinger" activeClassName="meny--lenke-active" className="meny--lenke meny--lenke-innstillinger">
+                        <NavLink to="/pam-stillingsok/innstillinger" activeClassName="meny--lenke-active" className="meny--lenke meny--lenke-innstillinger">
                             <Normaltekst className="meny--lenke-inner">Innstillinger<NavFrontendChevron className="meny--chevron" /></Normaltekst>
                         </NavLink>
                     </div>
@@ -174,7 +194,7 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
                         <div className="mobilmeny--separator" />
                         {tabs.map((tab) => (
                             applikasjon === tab.app ? (
-                                tab.href === '/stillinger' ? (
+                                tab.href === '/pam-stillingsok' ? (
                                     <div className="mobilmeny--lenke-wrapper" key={tab.href}>
                                         <NavLink onClick={this.hideMenu} isActive={stillingssokTabActive} to={tab.href} activeClassName="mobilmeny--lenke-active" className="mobilmeny--lenke">
                                             <Normaltekst className="mobilmeny--lenke-inner">{tab.tittel}<NavFrontendChevron className="mobilmeny--chevron" /></Normaltekst>
@@ -197,11 +217,11 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
                         ))}
                         <div className="mobilmeny--lenke-wrapper">
                             {applikasjon === PersonbrukerApplikasjon.STILLINGSSOK ? (
-                                <NavLink onClick={this.hideMenu} to="/stillinger/innstillinger" activeClassName="mobilmeny--lenke-active" className="mobilmeny--lenke">
+                                <NavLink onClick={this.hideMenu} to="/pam-stillingsok/innstillinger" activeClassName="mobilmeny--lenke-active" className="mobilmeny--lenke">
                                     <Normaltekst className="mobilmeny--lenke-inner">Innstillinger<NavFrontendChevron className="mobilmeny--chevron" /></Normaltekst>
                                 </NavLink>
                             ) : (
-                                <a onClick={this.hideMenu} href="/stillinger/innstillinger" className="mobilmeny--lenke">
+                                <a onClick={this.hideMenu} href="/pam-stillingsok/innstillinger" className="mobilmeny--lenke">
                                     <Normaltekst className="mobilmeny--lenke-inner">Innstillinger<NavFrontendChevron className="mobilmeny--chevron" /></Normaltekst>
                                 </a>
                             )}

--- a/pam-frontend-header/src/personbruker/InnloggetMeny.tsx
+++ b/pam-frontend-header/src/personbruker/InnloggetMeny.tsx
@@ -162,7 +162,7 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
                 <div className="meny">
                     {tabs.map((tab) => (
                         applikasjon === tab.app ? (
-                            tab.href === '/pam-stillingsok' ? (
+                            tab.href === '/' ? (
                                 <div className="meny--lenke-wrapper" key={tab.href}>
                                     <NavLink to={tab.href} isActive={stillingssokTabActive} activeClassName="meny--lenke-active" className="meny--lenke lenke">
                                         <span className="meny--lenke-inner" tabIndex={-1}>{tab.tittel}<NavFrontendChevron className="meny--chevron" /></span>

--- a/pam-frontend-header/src/personbruker/InnloggetMeny.tsx
+++ b/pam-frontend-header/src/personbruker/InnloggetMeny.tsx
@@ -93,12 +93,23 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
                     <div className="innlogging">
                         <div>
                             {personbruker && personbruker.navn && (
-                                <NavLink to="/stillinger/innstillinger" className="meny--navn lenke typo-normal" activeClassName="meny--navn-active">
-                                    <div className="meny--navn-inner" tabIndex={-1}>
-                                        <span className="meny--navn__text">{personbruker.navn}</span>
-                                        <span className="meny--tannhjul"/>
-                                    </div>
-                                </NavLink>
+                                <div>
+                                    {applikasjon === PersonbrukerApplikasjon.STILLINGSSOK ? (
+                                        <NavLink to="/stillinger/innstillinger" className="meny--navn lenke typo-normal" activeClassName="meny--navn-active">
+                                            <div className="meny--navn-inner" tabIndex={-1}>
+                                                <span className="meny--navn__text">{personbruker.navn}</span>
+                                                <span className="meny--tannhjul"/>
+                                            </div>
+                                        </NavLink>
+                                    ) : (
+                                        <a href="/stillinger/innstillinger" className="meny--navn lenke typo-normal">
+                                            <div className="meny--navn-inner" tabIndex={-1}>
+                                                <span className="meny--navn__text">{personbruker.navn}</span>
+                                                <span className="meny--tannhjul"/>
+                                            </div>
+                                        </a>
+                                    )}
+                                </div>
                             )}
                         </div>
                         <div>
@@ -178,9 +189,15 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
                             )
                         ))}
                         <div className="mobilmeny--lenke-wrapper">
-                            <NavLink onClick={this.hideMenu} to="/pam-stillingsok/innstillinger" activeClassName="mobilmeny--lenke-active" className="mobilmeny--lenke">
-                                <Normaltekst className="mobilmeny--lenke-inner">Innstillinger<NavFrontendChevron className="mobilmeny--chevron" /></Normaltekst>
-                            </NavLink>
+                            {applikasjon === PersonbrukerApplikasjon.STILLINGSSOK ? (
+                                <NavLink onClick={this.hideMenu} to="/stillinger/innstillinger" activeClassName="mobilmeny--lenke-active" className="mobilmeny--lenke">
+                                    <Normaltekst className="mobilmeny--lenke-inner">Innstillinger<NavFrontendChevron className="mobilmeny--chevron" /></Normaltekst>
+                                </NavLink>
+                            ) : (
+                                <a onClick={this.hideMenu} href="/stillinger/innstillinger" className="mobilmeny--lenke">
+                                    <Normaltekst className="mobilmeny--lenke-inner">Innstillinger<NavFrontendChevron className="mobilmeny--chevron" /></Normaltekst>
+                                </a>
+                            )}
                         </div>
                         <div className="mobilmeny--loggut-wrapper">
                             <Knapp onClick={onLoggUt} id="logg-ut" className="knapp knapp--mini mobilmeny--loggut">

--- a/pam-frontend-header/src/personbruker/InnloggetMeny.tsx
+++ b/pam-frontend-header/src/personbruker/InnloggetMeny.tsx
@@ -6,7 +6,8 @@ import NavFrontendChevron from "nav-frontend-chevron";
 
 export enum PersonbrukerApplikasjon {
     STILLINGSSOK = 'STILLINGSSOK',
-    CV = 'CV'
+    CV = 'CV',
+    JOBBPROFIL = 'JOBBPROFIL'
 }
 
 export interface PersonbrukerTab {
@@ -40,7 +41,13 @@ const tabs : Array<PersonbrukerTab> = [
         tittel: 'CV',
         href: '/cv/cv',
         app: PersonbrukerApplikasjon.CV
+    },
+    {
+        tittel: 'Jobbprofil',
+        href: '/jobbprofil',
+        app: PersonbrukerApplikasjon.JOBBPROFIL
     }
+
 ];
 
 interface InnloggetToppProps {

--- a/pam-frontend-header/src/personbruker/InnloggetMeny.tsx
+++ b/pam-frontend-header/src/personbruker/InnloggetMeny.tsx
@@ -4,39 +4,49 @@ import { Link, NavLink } from "react-router-dom";
 import { Normaltekst } from "nav-frontend-typografi";
 import NavFrontendChevron from "nav-frontend-chevron";
 
-export enum PersonbrukerTabId {
+export enum PersonbrukerApplikasjon {
     STILLINGSSOK = 'STILLINGSSOK',
-    FAVORITTER = 'FAVORITTER',
-    LAGREDESOK = 'LAGREDESOK'
+    CV = 'CV'
 }
 
-interface PersonbrukerTab {
-    id: PersonbrukerTabId;
+export interface PersonbrukerTab {
     tittel: string;
     href: string;
+    app: PersonbrukerApplikasjon
 }
 
 const tabs : Array<PersonbrukerTab> = [
     {
-        id: PersonbrukerTabId.STILLINGSSOK,
+        tittel: 'Min side',
+        href: '/cv',
+        app: PersonbrukerApplikasjon.CV
+    },
+    {
         tittel: 'Stillingssøk',
-        href: '/'
+        href: '/stillinger',
+        app: PersonbrukerApplikasjon.STILLINGSSOK
     },
     {
-        id: PersonbrukerTabId.FAVORITTER,
         tittel: 'Favoritter',
-        href: '/pam-stillingsok/favoritter'
+        href: '/stillinger/favoritter',
+        app: PersonbrukerApplikasjon.STILLINGSSOK
     },
     {
-        id: PersonbrukerTabId.LAGREDESOK,
         tittel: 'Lagrede søk',
-        href: '/pam-stillingsok/lagrede-sok'
+        href: '/stillinger/lagrede-sok',
+        app: PersonbrukerApplikasjon.STILLINGSSOK
+    },
+    {
+        tittel: 'CV',
+        href: '/cv/cv',
+        app: PersonbrukerApplikasjon.CV
     }
 ];
 
 interface InnloggetToppProps {
     onLoggUt: () => void;
     personbruker: { navn: string }
+    applikasjon: PersonbrukerApplikasjon
 }
 
 interface StateProps {
@@ -72,7 +82,7 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
 
 
     render() {
-        const { personbruker, onLoggUt } = this.props;
+        const { personbruker, onLoggUt, applikasjon } = this.props;
         const { showMobileMenu } = this.state;
         return (
             <div className="Innloggetmeny">
@@ -83,7 +93,7 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
                     <div className="innlogging">
                         <div>
                             {personbruker && personbruker.navn && (
-                                <Link to="/pam-stillingsok/innstillinger" className="meny--navn lenke typo-normal">
+                                <Link to="/stillinger/innstillinger" className="meny--navn lenke typo-normal">
                                     <span className="meny--navn__text">{personbruker.navn}</span>
                                     <div className="meny--tannhjul" />
                                 </Link>
@@ -111,17 +121,25 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
                 </div>
                 <div className="meny">
                     {tabs.map((tab) => (
-                        tab.href === "/" ? (
-                            <div className="meny--lenke-wrapper" key={tab.id}>
-                                <NavLink isActive={stillingssokTabActive} to={tab.href} activeClassName="meny--lenke-active" className="meny--lenke lenke">
-                                    <span className="meny--lenke-inner">{tab.tittel}<NavFrontendChevron className="meny--chevron" /></span>
-                                </NavLink>
-                            </div>
+                        applikasjon === tab.app ? (
+                            tab.href === '/stillinger' ? (
+                                <div className="meny--lenke-wrapper" key={tab.href}>
+                                    <NavLink to={tab.href} isActive={stillingssokTabActive} activeClassName="meny--lenke-active" className="meny--lenke lenke">
+                                        <span className="meny--lenke-inner">{tab.tittel}<NavFrontendChevron className="meny--chevron" /></span>
+                                    </NavLink>
+                                </div>
+                            ) : (
+                                <div className="meny--lenke-wrapper" key={tab.href}>
+                                    <NavLink to={tab.href} exact={tab.href === '/cv'} activeClassName="meny--lenke-active" className="meny--lenke lenke">
+                                        <span className="meny--lenke-inner">{tab.tittel}<NavFrontendChevron className="meny--chevron" /></span>
+                                    </NavLink>
+                                </div>
+                            )
                         ) : (
-                            <div className="meny--lenke-wrapper" key={tab.id}>
-                                <NavLink to={tab.href} activeClassName="meny--lenke-active" className="meny--lenke lenke">
+                            <div className="meny--lenke-wrapper" key={tab.href}>
+                                <a href={tab.href} className="meny--lenke lenke">
                                     <span className="meny--lenke-inner">{tab.tittel}<NavFrontendChevron className="meny--chevron" /></span>
-                                </NavLink>
+                                </a>
                             </div>
                         )
                     ))}
@@ -135,17 +153,25 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
                     <div className="mobilmeny">
                         <div className="mobilmeny--separator" />
                         {tabs.map((tab) => (
-                            tab.href === "/" ? (
-                                <div className="mobilmeny--lenke-wrapper" key={tab.id}>
-                                    <NavLink onClick={this.hideMenu} isActive={stillingssokTabActive} to={tab.href} activeClassName="mobilmeny--lenke-active" className="mobilmeny--lenke">
-                                        <Normaltekst className="mobilmeny--lenke-inner">{tab.tittel}<NavFrontendChevron className="mobilmeny--chevron" /></Normaltekst>
-                                    </NavLink>
-                                </div>
+                            applikasjon === tab.app ? (
+                                tab.href === '/stillinger' ? (
+                                    <div className="mobilmeny--lenke-wrapper" key={tab.href}>
+                                        <NavLink onClick={this.hideMenu} isActive={stillingssokTabActive} to={tab.href} activeClassName="mobilmeny--lenke-active" className="mobilmeny--lenke">
+                                            <Normaltekst className="mobilmeny--lenke-inner">{tab.tittel}<NavFrontendChevron className="mobilmeny--chevron" /></Normaltekst>
+                                        </NavLink>
+                                    </div>
+                                ) : (
+                                    <div className="mobilmeny--lenke-wrapper" key={tab.href}>
+                                        <NavLink onClick={this.hideMenu} to={tab.href} exact={tab.href === '/cv'} activeClassName="mobilmeny--lenke-active" className="mobilmeny--lenke">
+                                            <Normaltekst className="mobilmeny--lenke-inner">{tab.tittel}<NavFrontendChevron className="mobilmeny--chevron" /></Normaltekst>
+                                        </NavLink>
+                                    </div>
+                                )
                             ) : (
-                                <div className="mobilmeny--lenke-wrapper" key={tab.id}>
-                                    <NavLink onClick={this.hideMenu} to={tab.href} activeClassName="mobilmeny--lenke-active" className="mobilmeny--lenke">
+                                <div className="mobilmeny--lenke-wrapper" key={tab.href}>
+                                    <a onClick={this.hideMenu} href={tab.href} className="mobilmeny--lenke">
                                         <Normaltekst className="mobilmeny--lenke-inner">{tab.tittel}<NavFrontendChevron className="mobilmeny--chevron" /></Normaltekst>
-                                    </NavLink>
+                                    </a>
                                 </div>
                             )
                         ))}

--- a/pam-frontend-header/src/personbruker/PersonbrukerHeaderMeny.less
+++ b/pam-frontend-header/src/personbruker/PersonbrukerHeaderMeny.less
@@ -126,6 +126,13 @@
     margin-right: 36px;
   }
 
+  @media (max-width: 1000px) {
+    .meny--lenke-wrapper {
+      margin-left: 19px;
+      margin-right: 19px;
+    }
+  }
+
   .meny--lenke {
     font-size: 16px;
     padding: 8px 2px;

--- a/pam-frontend-header/src/personbruker/PersonbrukerHeaderMeny.tsx
+++ b/pam-frontend-header/src/personbruker/PersonbrukerHeaderMeny.tsx
@@ -3,6 +3,7 @@ import { Personbruker } from './PropTypes';
 import './PersonbrukerHeaderMeny.less';
 import { IkkeInnloggetMeny } from "./IkkeInnloggetMeny";
 import { InnloggetMeny } from "./InnloggetMeny";
+import { PersonbrukerApplikasjon } from '..';
 
 
 interface PersonbrukerHeaderMenyProps {
@@ -10,13 +11,14 @@ interface PersonbrukerHeaderMenyProps {
   onLoggInn: () => void;
   personbruker: Personbruker;
   erInnlogget: boolean;
+  applikasjon: PersonbrukerApplikasjon
 }
 
 
-export const PersonbrukerHeaderMeny = ({ onLoggUt, erInnlogget, personbruker, onLoggInn } : PersonbrukerHeaderMenyProps) => (
+export const PersonbrukerHeaderMeny = ({ onLoggUt, erInnlogget, personbruker, onLoggInn, applikasjon } : PersonbrukerHeaderMenyProps) => (
     <div className="HeaderMeny">
         {erInnlogget ? (
-            <InnloggetMeny onLoggUt={onLoggUt} personbruker={personbruker} />
+            <InnloggetMeny onLoggUt={onLoggUt} personbruker={personbruker} applikasjon={applikasjon} />
         ) : (
             <IkkeInnloggetMeny onLoggInn={onLoggInn} />
         )}

--- a/pam-frontend-header/src/personbruker/PersonbrukerHeaderMeny.tsx
+++ b/pam-frontend-header/src/personbruker/PersonbrukerHeaderMeny.tsx
@@ -16,10 +16,10 @@ interface PersonbrukerHeaderMenyProps {
 }
 
 
-export const PersonbrukerHeaderMeny = ({ onLoggUt, erInnlogget, personbruker, onLoggInn, applikasjon, visAlleMenyPunkter } : PersonbrukerHeaderMenyProps) => (
+export const PersonbrukerHeaderMeny = ({ onLoggUt, erInnlogget, personbruker, onLoggInn, applikasjon, visAlleMenyPunkter = false } : PersonbrukerHeaderMenyProps) => (
     <div className="HeaderMeny">
         {erInnlogget ? (
-            <InnloggetMeny onLoggUt={onLoggUt} personbruker={personbruker} applikasjon={applikasjon} visAlleMenyPunkter={visAlleMenyPunkter || false} />
+            <InnloggetMeny onLoggUt={onLoggUt} personbruker={personbruker} applikasjon={applikasjon} visAlleMenyPunkter={visAlleMenyPunkter} />
         ) : (
             <IkkeInnloggetMeny onLoggInn={onLoggInn} />
         )}

--- a/pam-frontend-header/src/personbruker/PersonbrukerHeaderMeny.tsx
+++ b/pam-frontend-header/src/personbruker/PersonbrukerHeaderMeny.tsx
@@ -11,14 +11,15 @@ interface PersonbrukerHeaderMenyProps {
   onLoggInn: () => void;
   personbruker: Personbruker;
   erInnlogget: boolean;
-  applikasjon: PersonbrukerApplikasjon
+  applikasjon: PersonbrukerApplikasjon;
+  visAlleMenyPunkter?: boolean;
 }
 
 
-export const PersonbrukerHeaderMeny = ({ onLoggUt, erInnlogget, personbruker, onLoggInn, applikasjon } : PersonbrukerHeaderMenyProps) => (
+export const PersonbrukerHeaderMeny = ({ onLoggUt, erInnlogget, personbruker, onLoggInn, applikasjon, visAlleMenyPunkter } : PersonbrukerHeaderMenyProps) => (
     <div className="HeaderMeny">
         {erInnlogget ? (
-            <InnloggetMeny onLoggUt={onLoggUt} personbruker={personbruker} applikasjon={applikasjon} />
+            <InnloggetMeny onLoggUt={onLoggUt} personbruker={personbruker} applikasjon={applikasjon} visAlleMenyPunkter={visAlleMenyPunkter || false} />
         ) : (
             <IkkeInnloggetMeny onLoggInn={onLoggInn} />
         )}


### PR DESCRIPTION
- Legge til CV og jobbprofil som menypunkter
- Bruke NavLink for url'er i samme applikasjon, og a-tags for url'er utenfor applikasjonen. Må da sende med applikasjon som props.
- Prop `visAlleMenypunkter` brukes for å bestemme om alle menypunkter skal vises, siden CV ikke skal være synlig i header i stillingssøket før 1. feb.

Jira: https://jira.adeo.no/browse/PAM-1440

> Akseptansekriterier
> 
> 1.
> Gitt at jeg som personbruker har logget inn fra forsiden på Arbeidsplassen, så skal jeg komme til Min side (Andre hovedmenypunkter er: Stillingssøk, Favoritter, Lagrede søk, CV, Jobbprofil)
> så skal jeg enkelt kunne bevege meg rundt i alle tjenestene som jeg har tilgang til