### PR TITLE
PAM-2026 Endrer til å bruke /cv/innstillinger fra CV og jobbprofil

### DIFF
--- a/pam-frontend-header/README.md
+++ b/pam-frontend-header/README.md
@@ -4,6 +4,17 @@
 
 [![NPM](https://img.shields.io/npm/v/pam-frontend-header.svg)](https://www.npmjs.com/package/pam-frontend-header)
 
+## Start
+For å starte applikasjonen første gang må du legge til en mappe /dist.
+Fra /pam-frontend-header i terminalen:
+
+```bash
+mkdir dist
+```
+```bash
+npm start
+```
+
 ## Install
 
 ```bash

--- a/pam-frontend-header/src/personbruker/InnloggetMeny.tsx
+++ b/pam-frontend-header/src/personbruker/InnloggetMeny.tsx
@@ -142,6 +142,7 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
                             {personbruker && personbruker.navn && (
                                 <div>
                                     {applikasjon === PersonbrukerApplikasjon.STILLINGSSOK ? (
+                                        // TODO: Endre NavLink to="/stillinger/innstillinger" til a href="/cv/innstillinger" når CV lanseres
                                         <NavLink
                                             to="/stillinger/innstillinger"
                                             onClick={this.onNavigationClick("/stillinger/innstillinger")}
@@ -154,16 +155,16 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
                                             </div>
                                         </NavLink>
                                     ) : (
-                                        <a
-                                            href="/stillinger/innstillinger"
-                                            onClick={this.onNavigationClick("/stillinger/innstillinger")}
+                                        <NavLink
+                                            to='/cv/innstillinger'
+                                            onClick={this.onNavigationClick("/cv/innstillinger")}
                                             className="meny--navn lenke typo-normal"
                                         >
                                             <div className="meny--navn-inner" tabIndex={-1}>
                                                 <span className="meny--navn__text">{personbruker.navn}</span>
                                                 <span className="meny--tannhjul"/>
                                             </div>
-                                        </a>
+                                        </NavLink>
                                     )}
                                 </div>
                             )}

--- a/pam-frontend-header/src/personbruker/InnloggetMeny.tsx
+++ b/pam-frontend-header/src/personbruker/InnloggetMeny.tsx
@@ -154,17 +154,29 @@ export class InnloggetMeny extends React.Component<InnloggetToppProps, StateProp
                                                 <span className="meny--tannhjul"/>
                                             </div>
                                         </NavLink>
-                                    ) : (
-                                        <NavLink
-                                            to='/cv/innstillinger'
-                                            onClick={this.onNavigationClick("/cv/innstillinger")}
-                                            className="meny--navn lenke typo-normal"
-                                        >
-                                            <div className="meny--navn-inner" tabIndex={-1}>
-                                                <span className="meny--navn__text">{personbruker.navn}</span>
-                                                <span className="meny--tannhjul"/>
-                                            </div>
-                                        </NavLink>
+                                    ) : (applikasjon === PersonbrukerApplikasjon.CV ? (
+                                            <NavLink
+                                                to='/cv/innstillinger'
+                                                onClick={this.onNavigationClick('/cv/innstillinger')}
+                                                className="meny--navn lenke typo-normal"
+                                            >
+                                                <div className="meny--navn-inner" tabIndex={-1}>
+                                                    <span className="meny--navn__text">{personbruker.navn}</span>
+                                                    <span className="meny--tannhjul"/>
+                                                </div>
+                                            </NavLink>
+                                        ) : (
+                                            <a
+                                                href="/cv/innstillinger"
+                                                onClick={this.onNavigationClick('/stillinger/innstillinger')}
+                                                className="meny--navn lenke typo-normal"
+                                            >
+                                                <div className="meny--navn-inner" tabIndex={-1}>
+                                                    <span className="meny--navn__text">{personbruker.navn}</span>
+                                                    <span className="meny--tannhjul"/>
+                                                </div>
+                                            </a>
+                                        )
                                     )}
                                 </div>
                             )}


### PR DESCRIPTION
Endrer til å bruke /cv/innstillinger fra CV og jobbprofil i stedet for /stillinger/innstillinger.

Vi skal kun bruke cv/innstillinger når CV blir lansert, men siden denne siden ligger bak feature toggle frem til lansering må fortsatt stillingsøket bruke sin egen innstillinger-side frem til feature togglen fjernes.